### PR TITLE
refactor: use dotenv

### DIFF
--- a/app/auth.tsx
+++ b/app/auth.tsx
@@ -1,3 +1,3 @@
 export default {
-  apiKey: "YOUR_API_KEY",
+  apiKey: process.env.YT_API_KEY,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@remix-run/dev": "^1.2.1",
         "@types/react": "^17.0.24",
         "@types/react-dom": "^17.0.9",
+        "dotenv": "^16.0.0",
         "typescript": "^4.1.2"
       },
       "engines": {
@@ -2227,6 +2228,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -8514,6 +8524,12 @@
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
       }
+    },
+    "dotenv": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+      "dev": true
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@remix-run/dev": "^1.2.1",
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9",
+    "dotenv": "^16.0.0",
     "typescript": "^4.1.2"
   },
   "engines": {
@@ -30,7 +31,7 @@
   "scripts": {
     "postinstall": "remix setup node",
     "build": "cross-env NODE_ENV=production remix build",
-    "dev": "cross-env NODE_ENV=development remix dev",
+    "dev": "node -r dotenv/config node_modules/.bin/remix dev",
     "start": "cross-env NODE_ENV=production remix-serve build"
   }
 }


### PR DESCRIPTION
From this increment, developers should have a `.env` file in the root of the project folder.

The `.env` file will never be checked into the SCM repository for security reasons. It is in the `.gitignore` file

### ENV vars:

* `YT_API_KEY` - Youtube API Key
* `NODE_ENV` - `"production"` or `"development"`

closes #5